### PR TITLE
set the package to be private so npm -g upgrade would stop failing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "app.js",
   "author": "Mike Plugge",
   "license": "MIT",
+  "private": true,
   "dependencies": {
     "body-parser": "^1.17.2",
     "command-line-args": "^4.0.6",


### PR DESCRIPTION
I have other node packages installed from the npm registry, and ran into a problem with trying to upgrade them after installing the Roon web controller. "npm -g upgrade" started failing because it was getting a 404 error: 

`npm ERR! code E404
npm ERR! 404 Registry returned 404 for GET on https://registry.npmjs.org/roon-web-controller
npm ERR! 404 
npm ERR! 404  'roon-web-controller' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.
`

I assume this is because the module isn't published on the npm registry. So for now I set the module to be private in package.json. Maybe sometime you'll want to publish it and need to take the private line out, but this is what I needed to do to fix npm upgrade.