### PR TITLE
Add route to get original-size cover image

### DIFF
--- a/app.js
+++ b/app.js
@@ -326,6 +326,15 @@ app.get('/roonapi/getImage', function(req, res){
     });
 });
 
+app.get('/roonapi/getOriginalImage', function(req, res){
+    core.services.RoonApiImage.get_image(req.query.image_key, {"format": "image/jpeg"}, function(cb, contentType, body) {
+        res.contentType = contentType;
+
+        res.writeHead(200, {'Content-Type': 'image/jpeg' });
+        res.end(body, 'binary');
+    });
+});
+
 app.post('/roonapi/goRefreshBrowse', function(req, res){
     refresh_browse(req.body.zone_id, req.body.options, function(payload){
         res.send({"data": payload});


### PR DESCRIPTION
This allows retrieval of the original-size cover image. It's identical to getImage, except without passing the size parameters, so node-roon-api provides the original size image.

I'm working on a now-playing view for a 4K TV, which I will contribute separately, and that needs images bigger than 1000x1000 where they exist. This is the only modification needed to app.js for that.